### PR TITLE
Write report omits values by default

### DIFF
--- a/envstruct.go
+++ b/envstruct.go
@@ -15,7 +15,7 @@ const (
 	indexEnvVar = 0
 
 	tagRequired = "required"
-	tagNoReport = "noreport"
+	tagReport   = "report"
 )
 
 // Unmarshaller is a type which unmarshals itself from an environment variable.

--- a/envstruct_suite_test.go
+++ b/envstruct_suite_test.go
@@ -81,13 +81,24 @@ type LargeTestStruct struct {
 }
 
 type SmallTestStruct struct {
-	HiddenThing        string   `env:"HIDDEN_THING,noreport"`
-	StringThing        string   `env:"STRING_THING"`
-	BoolThing          bool     `env:"BOOL_THING"`
-	IntThing           int      `env:"INT_THING"`
-	URLThing           *url.URL `env:"URL_THING"`
-	StringSliceThing   []string `env:"STRING_SLICE_THING"`
-	CaseSensitiveThing string   `env:"CaSe_SeNsItIvE_ThInG"`
+	HiddenThing           string   `env:"HIDDEN_THING"`
+	StringThing           string   `env:"STRING_THING,report"`
+	BoolThing             bool     `env:"BOOL_THING,report"`
+	IntThing              int      `env:"INT_THING,report"`
+	URLThing              *url.URL `env:"URL_THING,report"`
+	StringSliceThing      []string `env:"STRING_SLICE_THING,report"`
+	CaseSensitiveThing    string   `env:"CaSe_SeNsItIvE_ThInG,report"`
+	SmallTestSubStruct    SmallTestSubStruct
+	PtrSmallTestSubStruct *SmallTestSubStruct
+	NotReported           SmallTestStructWithNoEnv
+}
+
+type SmallTestSubStruct struct {
+	SecretThing string `env:"SECRET_THING"`
+}
+
+type SmallTestStructWithNoEnv struct {
+	FieldThing string
 }
 
 type ToEnvTestStruct struct {

--- a/example/example.go
+++ b/example/example.go
@@ -17,9 +17,9 @@ func (c *Credentials) UnmarshalEnv(data string) error {
 }
 
 type HostInfo struct {
-	Credentials Credentials `env:"CREDENTIALS, required, noreport"`
-	IP          string      `env:"HOST_IP,     required"`
-	Port        int         `env:"HOST_PORT"`
+	Credentials Credentials `env:"CREDENTIALS, required"`
+	IP          string      `env:"HOST_IP,     required, report"`
+	Port        int         `env:"HOST_PORT,             report"`
 }
 
 func main() {

--- a/report_test.go
+++ b/report_test.go
@@ -41,13 +41,15 @@ var _ = Describe("Report", func() {
 })
 
 const (
-	expectedReportOutput = `FIELD NAME:         TYPE:     ENV:                  REQUIRED:  VALUE:
-HiddenThing         string    HIDDEN_THING          false      (OMITTED)
-StringThing         string    STRING_THING          false      stringy thingy
-BoolThing           bool      BOOL_THING            false      true
-IntThing            int       INT_THING             false      100
-URLThing            *url.URL  URL_THING             false      http://github.com/some/path
-StringSliceThing    []string  STRING_SLICE_THING    false      [one two three]
-CaseSensitiveThing  string    CASE_SENSITIVE_THING  false      case sensitive
+	expectedReportOutput = `FIELD NAME:                         TYPE:     ENV:                  REQUIRED:  VALUE:
+SmallTestStruct.HiddenThing         string    HIDDEN_THING          false      (OMITTED)
+SmallTestStruct.StringThing         string    STRING_THING          false      stringy thingy
+SmallTestStruct.BoolThing           bool      BOOL_THING            false      true
+SmallTestStruct.IntThing            int       INT_THING             false      100
+SmallTestStruct.URLThing            *url.URL  URL_THING             false      http://github.com/some/path
+SmallTestStruct.StringSliceThing    []string  STRING_SLICE_THING    false      [one two three]
+SmallTestStruct.CaseSensitiveThing  string    CASE_SENSITIVE_THING  false      case sensitive
+SmallTestSubStruct.SecretThing      string    SECRET_THING          false      (OMITTED)
+SmallTestSubStruct.SecretThing      string    SECRET_THING          false      (OMITTED)
 `
 )


### PR DESCRIPTION
* Removes `noreport` tag and adds `report` tag.
* WriteReport omits values by default, `report` must be added to the `env` struct tag in order to opt into reporting a value.
* WriteReport ignores struct fields without `env` struct tags.
* WriteReport respects `report` tag on substructs with `env` struct tags.

This is a breaking change for the `noreport` option.

Fixes #7