### PR TITLE
Add support for complex64/complex128 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Credentials: {Username:my-user Password:my-password}
 - [x] uint64
 - [x] float32
 - [x] float64
-- [ ] complex64
-- [ ] complex128
+- [x] complex64
+- [x] complex128
 - [x] []slice (Slices of any other supported type. Environment variable should
   have coma separated values)
 - [x] time.Duration

--- a/envstruct.go
+++ b/envstruct.go
@@ -166,6 +166,8 @@ func setField(value reflect.Value, input string, hasEnvTag bool) (missing []stri
 		return nil, setUint(value, input)
 	case reflect.Float32, reflect.Float64:
 		return nil, setFloat(value, input)
+	case reflect.Complex64, reflect.Complex128:
+		return nil, setComplex(value, input)
 	case reflect.Slice:
 		return nil, setSlice(value, input, hasEnvTag)
 	case reflect.Map:
@@ -273,6 +275,23 @@ func setFloat(value reflect.Value, input string) error {
 	}
 
 	value.SetFloat(float64(n))
+
+	return nil
+}
+
+func setComplex(value reflect.Value, input string) error {
+	var n complex128
+
+	count, err := fmt.Sscanf(input, "%g", &n)
+	if err != nil {
+		return err
+	}
+
+	if count != 1 {
+		return fmt.Errorf("Expected to parse 1 complex number, found %d", count)
+	}
+
+	value.SetComplex(n)
 
 	return nil
 }

--- a/envstruct_suite_test.go
+++ b/envstruct_suite_test.go
@@ -32,6 +32,9 @@ var (
 		"FLOAT_THING":             "3.14159",
 		"FLOAT32_THING":           "1.2345",
 		"FLOAT64_THING":           "9.8765",
+		"COMPLEX_THING":           "(3+14159i)",
+		"COMPLEX64_THING":         "(1+2345i)",
+		"COMPLEX128_THING":        "(9+8765i)",
 		"POINTER_TO_STRING":       "pointy stringy thingy",
 		"POINTER_TO_BOOL":         "true",
 		"POINTER_TO_INT":          "20",
@@ -73,6 +76,9 @@ type LargeTestStruct struct {
 	Float32Thing float32 `env:"FLOAT32_THING"`
 	Float64Thing float64 `env:"FLOAT64_THING"`
 
+	Complex64Thing  complex64  `env:"COMPLEX64_THING"`
+	Complex128Thing complex128 `env:"COMPLEX128_THING"`
+
 	PtrToString *string `env:"POINTER_TO_STRING"`
 	PtrToBool   *bool   `env:"POINTER_TO_BOOL"`
 	PtrToInt    *int    `env:"POINTER_TO_INT"`
@@ -96,14 +102,15 @@ type LargeTestStruct struct {
 }
 
 type SmallTestStruct struct {
-	HiddenThing           string   `env:"HIDDEN_THING"`
-	StringThing           string   `env:"STRING_THING,report"`
-	BoolThing             bool     `env:"BOOL_THING,report"`
-	IntThing              int      `env:"INT_THING,report"`
-	FloatThing            float64  `env:"FLOAT_THING,report"`
-	URLThing              *url.URL `env:"URL_THING,report"`
-	StringSliceThing      []string `env:"STRING_SLICE_THING,report"`
-	CaseSensitiveThing    string   `env:"CaSe_SeNsItIvE_ThInG,report"`
+	HiddenThing           string     `env:"HIDDEN_THING"`
+	StringThing           string     `env:"STRING_THING,report"`
+	BoolThing             bool       `env:"BOOL_THING,report"`
+	IntThing              int        `env:"INT_THING,report"`
+	FloatThing            float64    `env:"FLOAT_THING,report"`
+	ComplexThing          complex128 `env:"COMPLEX_THING,report"`
+	URLThing              *url.URL   `env:"URL_THING,report"`
+	StringSliceThing      []string   `env:"STRING_SLICE_THING,report"`
+	CaseSensitiveThing    string     `env:"CaSe_SeNsItIvE_ThInG,report"`
 	SmallTestSubStruct    SmallTestSubStruct
 	PtrSmallTestSubStruct *SmallTestSubStruct
 	NotReported           SmallTestStructWithNoEnv

--- a/envstruct_test.go
+++ b/envstruct_test.go
@@ -167,6 +167,16 @@ var _ = Describe("envstruct", func() {
 				})
 			})
 
+			Context("with complex types", func() {
+				It("populates the complex64 thing", func() {
+					Expect(ts.Complex64Thing).To(Equal(complex64(1 + 2345i)))
+				})
+
+				It("populates the complex128 thing", func() {
+					Expect(ts.Complex128Thing).To(Equal(complex128(9 + 8765i)))
+				})
+			})
+
 			Context("with pointers to primatives", func() {
 				It("populates the pointer to string thing", func() {
 					Expect(*ts.PtrToString).To(Equal("pointy stringy thingy"))

--- a/report_test.go
+++ b/report_test.go
@@ -41,16 +41,17 @@ var _ = Describe("Report", func() {
 })
 
 const (
-	expectedReportOutput = `FIELD NAME:                         TYPE:     ENV:                  REQUIRED:  VALUE:
-SmallTestStruct.HiddenThing         string    HIDDEN_THING          false      (OMITTED)
-SmallTestStruct.StringThing         string    STRING_THING          false      stringy thingy
-SmallTestStruct.BoolThing           bool      BOOL_THING            false      true
-SmallTestStruct.IntThing            int       INT_THING             false      100
-SmallTestStruct.FloatThing          float64   FLOAT_THING           false      3.14159
-SmallTestStruct.URLThing            *url.URL  URL_THING             false      http://github.com/some/path
-SmallTestStruct.StringSliceThing    []string  STRING_SLICE_THING    false      [one two three]
-SmallTestStruct.CaseSensitiveThing  string    CASE_SENSITIVE_THING  false      case sensitive
-SmallTestSubStruct.SecretThing      string    SECRET_THING          false      (OMITTED)
-SmallTestSubStruct.SecretThing      string    SECRET_THING          false      (OMITTED)
+	expectedReportOutput = `FIELD NAME:                         TYPE:       ENV:                  REQUIRED:  VALUE:
+SmallTestStruct.HiddenThing         string      HIDDEN_THING          false      (OMITTED)
+SmallTestStruct.StringThing         string      STRING_THING          false      stringy thingy
+SmallTestStruct.BoolThing           bool        BOOL_THING            false      true
+SmallTestStruct.IntThing            int         INT_THING             false      100
+SmallTestStruct.FloatThing          float64     FLOAT_THING           false      3.14159
+SmallTestStruct.ComplexThing        complex128  COMPLEX_THING         false      (3+14159i)
+SmallTestStruct.URLThing            *url.URL    URL_THING             false      http://github.com/some/path
+SmallTestStruct.StringSliceThing    []string    STRING_SLICE_THING    false      [one two three]
+SmallTestStruct.CaseSensitiveThing  string      CASE_SENSITIVE_THING  false      case sensitive
+SmallTestSubStruct.SecretThing      string      SECRET_THING          false      (OMITTED)
+SmallTestSubStruct.SecretThing      string      SECRET_THING          false      (OMITTED)
 `
 )


### PR DESCRIPTION
So, I mostly just wanted to knock these off the list even though nobody will ever use this.

There's no function to handle the parsing in `strconv`, so I used `fmt.Sscanf` to do it, which seems to work surprisingly well. I'm open to alternative solutions, but the parsing options for complex types seem pretty limited.